### PR TITLE
fix: regex mismatch

### DIFF
--- a/config/command.yml
+++ b/config/command.yml
@@ -1,5 +1,6 @@
 card:
-  - ^#gq *(\[CQ:at,qq=)?([0-9]*)
+  - ^#gq *\[CQ:at,qq=[0-9]+.*\]$
+  - ^#gq *[0-9]*$
 package:
   - ^#uid *[0-9]+$
 save:


### PR DESCRIPTION
The origin regex `^#gq *(\[CQ:at,qq=)?([0-9]*)` used to match command `card` mismatch under many circumstances, and the `$` is missing.
for example, `#gq 12121abc`, `#gq abcd` and so on also got matched (which is not supposed, I guess)
by the way, I split them into two regex expressions.