### PR TITLE
bugfix: trivial bugfix about command `detail`

### DIFF
--- a/src/plugins/@help/detail.ts
+++ b/src/plugins/@help/detail.ts
@@ -17,6 +17,11 @@ async function main( sendMessage: ( content: string ) => any, message: Message )
 		commands = privateCommands[auth];
 	}
 	
+	if ( commandId < 1 || commandId > commands.length )
+	{
+		await sendMessage( `请输入正确的指令编号` );
+		return;
+	}
 	await sendMessage( commands[commandId-1].detail );
 }
 

--- a/src/plugins/@help/init.ts
+++ b/src/plugins/@help/init.ts
@@ -15,7 +15,7 @@ async function init(): Promise<any> {
 		key: "adachi.detail",
 		docs: [ "详细", "<编号>" ],
 		headers: [ "detail" ],
-		regexps: [ " [0-9]+" ],
+		regexps: [ " [0-9]+$" ],
 		authLimit: AuthLevel.Banned,
 		main: "detail"
 	} );


### PR DESCRIPTION
the previous regex allow users to input stuff like `#detail 123abc`, which will result in ID being parsed as `123`.
and there's not range check for the array index.

this PR improves the regex to prevent users from input non-numeric ID, and check if the ID goes out of range.

