### PR TITLE
fix: Adding `.gitignore` for some directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/config/
+/data/
+/database/
+/node_modules/


### PR DESCRIPTION
Adding these directories into `.gitignore` :
- `/config/`
- `/data/`
- `/database/`
- `/node_modules/`

these directories are generated when installing/running Adachi-Bot under the repo, but not a part of the source code