### PR TITLE
feat: Adding tool dice

### DIFF
--- a/src/plugins/tools/dice.ts
+++ b/src/plugins/tools/dice.ts
@@ -1,0 +1,83 @@
+// /src/plugins/tools/dice.ts
+// 2021 He Yang @kernel.bin <1160386205@qq.com>
+
+import { CommonMessageEventData as Message } from "oicq";
+
+const MAX_TIMES = 100;
+const MAX_FACES = 32767;
+
+function replyTimesIncorrect() {
+	return `掷骰子的次数应在 1 到 ${ MAX_TIMES } 之间`;
+}
+
+function replyFacesIncorrect() {
+	return `骰子面数次数应在 1 到 ${ MAX_FACES } 之间`;
+}
+
+function replyTopNIncorrect() {
+	return `最大的前 n 项显示数应在 1 到投骰子次数之间`;
+}
+
+function getRandomInt( maxNumber: number ): number {
+	return Math.floor( Math.random() * maxNumber ) + 1;
+}
+
+async function main( sendMessage: ( content: string ) => any, message: Message, match: string[] ): Promise<void> {
+	let times = 1, faces = 6, top_n = 0;
+	
+	// command format should looks like `r3d6k2`
+	if ( match[0] ) {
+		times = Number( match[0].substr( 1 ) );
+		if ( times < 1 || times > MAX_TIMES ) {
+			await sendMessage( replyTimesIncorrect() );
+			return;
+		}
+	}
+	if ( match[1] ) {
+		faces = Number( match[1].substr( 1 ) );
+		if ( faces < 1 || faces > MAX_FACES ) {
+			await sendMessage( replyFacesIncorrect() );
+			return;
+		}
+	}
+	if ( match[2] ) {
+		top_n = Number( match[2].substr( 1 ) );
+		if ( top_n < 1 || top_n > times ) {
+			await sendMessage( replyTopNIncorrect() );
+			return;
+		}
+	}
+	
+	let arr: number[] = []; // array to store the results
+	for ( let i = 0; i < times; i++ ) {
+		arr.push( getRandomInt( faces ) );
+	}
+	if ( top_n != 0 ) {
+		arr.sort( ( a, b ) => b - a ); // only sort the results when k is specified.
+	}
+	
+	// concat the result.
+	let result = `投骰子`;
+	if ( times != 1 ) {
+		result += ` ${ times } 次`;
+	}
+	if ( top_n != 0 ) {
+		result += `前 ${ top_n } 大`;
+	}
+	result += `结果为：\n`;
+	
+	let showitem = top_n == 0 ? times : top_n;
+	for ( let i = 0; i < showitem; i++ ) {
+		if ( i != 0 ) {
+			result += ` `;
+		}
+		result += arr[i];
+	}
+	
+	// send the result.
+	
+	await sendMessage( result );
+	return;
+}
+
+export { main }

--- a/src/plugins/tools/init.ts
+++ b/src/plugins/tools/init.ts
@@ -1,0 +1,19 @@
+// /src/plugins/tools/init.ts
+// 2021 He Yang @kernel.bin <1160386205@qq.com>
+
+import { addPlugin } from "../../modules/plugin";
+import { AuthLevel } from "../../modules/auth";
+
+async function init(): Promise<any> {
+	return addPlugin( "tools", {
+		commandType: "question",
+		key: "tools.dice",
+		docs: [ "掷骰", "r<次数>d<面数>k<取前n大>" ],
+		sentences: [ "^${HEADER}(r[0-9]+)?(d[0-9]+)(k[0-9]+)?$" ],
+		authLimit: AuthLevel.Banned,
+		main: "dice",
+		detail: "掷骰子：投掷一个或多个骰子。\n用法：r<次数>d<面数>k<取前n大>，r 和 k 为可选。\nExamples:\n    d6\n    r5d10\n    r10d6k2"
+	} );
+}
+
+export { init }


### PR DESCRIPTION
Adding tool `dice` for Adachi-bot.

usage:
`#d6`
*//dice 1 times*

`#r5d10` 
*// dice 5 times, values between 1 to 10*

`#r18d30k5` 
*// dice 18 times, values between 1 to 30, and only show the biggest 5 result*

*`#` is the command prefix, not a part of the command dice*