### PR TITLE
fix Order with  uppercase Cause error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adachi-bot",
-  "version": "2.2.12-feat4",
+  "version": "2.2.12-feat5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/modules/bot.ts
+++ b/src/modules/bot.ts
@@ -214,7 +214,7 @@ export default class Adachi {
 				const text: string = cmd.ignoreCase
 					? content.toLowerCase() : content;
 				messageData.raw_message = trim(
-					msg.removeStringPrefix( text, res.header )
+					msg.removeStringPrefix( text, res.header.toLowerCase() )
 					   .replace( / +/g, " " )
 				);
 			}


### PR DESCRIPTION
指令的默认ignoreCase为true，当设置指令中含有英文大写
bot.ts处理会自动转为小写，然后trim匹配不到转为小写的指令
在`#bind`命令中会出现错误，进而导致 `#uid-query` @他人，获取不到正确UID，查询报错parseInt错误
