### PR TITLE
support config loglevel to limit log info.

### DIFF
--- a/src/modules/logger.ts
+++ b/src/modules/logger.ts
@@ -16,7 +16,7 @@ export default class WebConfiguration {
 		this.tcpLoggerPort = config.webConsole.tcpLoggerPort;
 		this.deviceName = `[${ platformName[config.platform] }:${ config.number }]`;
 		this.setNetworkLayout();
-		const cfg = this.getConfiguration( config.webConsole.enable );
+		const cfg = this.getConfiguration( config.webConsole.enable, config.logLevel );
 		configure( cfg );
 	}
 	
@@ -30,7 +30,7 @@ export default class WebConfiguration {
 		} ) );
 	}
 	
-	private getConfiguration( enable: boolean ): Configuration {
+	private getConfiguration( enable: boolean, logLevel: string ): Configuration {
 		const console = { type: "console" };
 		const network = {
 			type: "tcp",
@@ -49,7 +49,7 @@ export default class WebConfiguration {
 		const Default = { appenders: [ "console" ], level: "off" };
 		const Device = {
 			appenders: [ "logFile", enable ? "network" : "console" ],
-			level: "debug"
+			level: logLevel
 		};
 		
 		return <Configuration>{


### PR DESCRIPTION
将配置文件中的`logLevel`配置应用起来，使BOT与`oicq`共用一个日志等级，以此配置限制BOT的日志输出。或者再加一个配置将两者的日志等级分别配置。