### PR TITLE
fixed: improved wish limit number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adachi-bot",
-  "version": "2.3.9",
+  "version": "2.3.9-bugfix1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adachi-bot",
-      "version": "2.3.7-bugfix1",
+      "version": "2.3.9-bugfix1",
       "license": "ISC",
       "dependencies": {
         "@types/body-parser": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adachi-bot",
-  "version": "2.3.9",
+  "version": "2.3.9-bugfix1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/plugins/genshin/achieves/wish.ts
+++ b/src/plugins/genshin/achieves/wish.ts
@@ -15,12 +15,20 @@ export async function main(
 	const param: string = messageData.raw_message;
 	
 	const wishLimitNum = config.wishLimitNum;
-	if ( wishLimitNum < 99 && ( ( /^\d+$/.test( param ) && parseInt( param ) > wishLimitNum ) || "until" === param ) ) {
+	let choice: string | null = await redis.getString( `silvery-star.wish-choice-${ userID }` );
+	const choiceTmp = choice || "角色";
+	let maxWishNum;
+	if ( choiceTmp === "武器" ) {
+		maxWishNum = 24;
+	} else {
+		// 常驻、角色、角色2
+		maxWishNum = 18;
+	}
+	if ( ( /^\d+$/.test( param ) && parseInt( param ) > wishLimitNum ) || ( wishLimitNum < maxWishNum && "until" === param ) ) {
 		await sendMessage( `由于服务器配置较低，请使用${ wishLimitNum }次以内的十连抽卡` );
 		return;
 	}
 	
-	let choice: string | null = await redis.getString( `silvery-star.wish-choice-${ userID }` );
 	if ( choice.length === 0 ) {
 		choice = "角色"
 		await redis.setString( `silvery-star.wish-choice-${ userID }`, "角色" );


### PR DESCRIPTION
修复 `wish` 指令限制次数小于99时 `until` 参数无法使用的问题，优化为武器池小于24无法使用，角色、角色2、常驻池小于18无法使用。