### PR TITLE
update to ver2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adachi-bot",
-  "version": "2.4.12-bugfix3",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "adachi-bot",
-  "version" : "2.4.12-bugfix3",
+  "version" : "2.5.1",
   "description" : "",
   "main" : "index.js",
   "scripts" : {

--- a/src/modules/bot.ts
+++ b/src/modules/bot.ts
@@ -314,11 +314,13 @@ export default class Adachi {
 		} )[0]
 		
 		if ( res.type === "unmatch" ) {
-			await sendMessage( `指令参数错误 ~ \n` +
-				`你的参数：${ res.param ? res.param : "无" }\n` +
-				`参数格式：${ cmd.desc[1] }\n` +
-				`参数说明：${ cmd.detail }`
-			);
+			if ( this.bot.config.matchPrompt ) {
+				await sendMessage( `指令参数错误 ~ \n` +
+					`你的参数：${ res.param ? res.param : "无" }\n` +
+					`参数格式：${ cmd.desc[1] }\n` +
+					`参数说明：${ cmd.detail }`
+				);
+			}
 			return;
 		}
 		

--- a/src/modules/command/main.ts
+++ b/src/modules/command/main.ts
@@ -191,17 +191,20 @@ export default class Command {
 						list.push(
 							...el.genRegExps.map( r => `(${ r.source })` )
 						);
+						
 						/* 是否存在指令起始符 */
 						const hasHeader = bot.config.header ? el.header.includes( bot.config.header ) : false;
 						const rawHeader = el.header.replace( bot.config.header, "" );
 						
-						/* 当指令头包括中文时，同时匹配是否存在起始符与指令头，否则不处理 */
-						/* 当未设置起始符时，不再添加指令头至unionReg */
-						const unMatchHeader: string = rawHeader.length !== 0 && /[\u4e00-\u9fa5]/.test( rawHeader )
-							? `${ hasHeader ? "(?=.*" + bot.config.header + ")" : "" }(?=.*${ rawHeader })`
-							: bot.config.header
-								? el.header
-								: "";
+						let unMatchHeader: string = "";
+						
+						if ( bot.config.fuzzyMatch && rawHeader.length !== 0 && /[\u4e00-\u9fa5]/.test( rawHeader ) ) {
+							/* 当开启模糊匹配、指令头包括中文时，同时匹配是否存在起始符与指令头 */
+							unMatchHeader = `${ hasHeader ? "(?=^" + bot.config.header + ")" : "" }(?=.*${ rawHeader })`
+						} else if ( bot.config.matchPrompt && bot.config.header && el.header ) {
+							/* 当开启格式检查提示、存在起始符时，添加指令头至unionReg */
+							unMatchHeader = "^" + el.header;
+						}
 						
 						if ( unMatchHeader.length === 0 ) {
 							return;

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -11,6 +11,8 @@ export default class BotConfig {
 	public readonly atUser: boolean;
 	public readonly atBOT: boolean;
 	public readonly addFriend: boolean;
+	public readonly fuzzyMatch: boolean;
+	public readonly matchPrompt: boolean;
 	public readonly dbPort: number;
 	public readonly dbPassword: string;
 	public readonly inviteAuth: AuthLevel;
@@ -48,6 +50,8 @@ export default class BotConfig {
 		atUser: false,
 		atBOT: false,
 		addFriend: true,
+		fuzzyMatch: false,
+		matchPrompt: true,
 		inviteAuth: "master",
 		countThreshold: 60,
 		groupIntervalTime: 1500,
@@ -78,7 +82,8 @@ export default class BotConfig {
 		const config: any = file.loadYAML( "setting" );
 		const checkFields: Array<keyof BotConfig> = [
 			"atBOT", "addFriend", "dbPassword",
-			"helpPort", "autoChat", "callTimes"
+			"helpPort", "autoChat", "callTimes",
+			"fuzzyMatch", "matchPrompt"
 		];
 		
 		for ( let key of checkFields ) {
@@ -98,6 +103,8 @@ export default class BotConfig {
 		this.atUser = config.atUser;
 		this.addFriend = config.addFriend;
 		this.autoChat = config.autoChat;
+		this.fuzzyMatch = config.fuzzyMatch;
+		this.matchPrompt = config.matchPrompt;
 		this.platform = config.platform;
 		this.password = config.password;
 		this.helpPort = config.helpPort;

--- a/src/plugins/@management/init.ts
+++ b/src/plugins/@management/init.ts
@@ -79,7 +79,7 @@ const upgrade: OrderConfig = {
 	auth: AuthLevel.Master,
 	main: "upgrade",
 	detail: "该指令用于检测并更新 bot 源码\n" +
-		"要求项目必须是通过 git clone 下载的\n" +
+		"要求项目必须是通过 git clone 下载的且不能为 win-start 启动\n" +
 		"若存在更新则会更新并重启 bot\n" +
 		"在指令后追加 -f 来覆盖本地修改强制更新"
 }

--- a/src/web-console/assets/styles/view/log.css
+++ b/src/web-console/assets/styles/view/log.css
@@ -6,6 +6,7 @@
 	bottom: 12px;
 	padding: var(--box-padding);
 	background-color: #ffffff;
+	user-select: none;
 	border-radius: 4px;
 	box-shadow: var(--box-shadow);
 	box-sizing: border-box;
@@ -107,6 +108,7 @@
 	background-color: #000;
 	width: 100%;
 	height: calc(100% - 38px);
+	user-select: auto;
 	font-family: Consolas, "宋体", monospace;
 }
 


### PR DESCRIPTION
- 新增 开启模糊匹配 配置项 `fuzzyMatch`，默认 `false`
- 新增 开启指令格式错误提示 配置项 `matchPrompt`，默认 `true`
- 模糊匹配修改为当配置 `header` 时，必须以 `header` 起始
- 修复控制台 去隐私复制 无法选中文本问题