### PR TITLE
add upgrade plugins cmd and fix the problem of incomplete information about the abyss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adachi-bot",
-  "version": "2.5.1-bugfix1",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adachi-bot",
-      "version": "2.4.11",
+      "version": "2.6.0",
       "license": "ISC",
       "dependencies": {
         "@types/body-parser": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "adachi-bot",
-  "version" : "2.5.1-bugfix1",
+  "version" : "2.6.0",
   "description" : "",
   "main" : "index.js",
   "scripts" : {

--- a/src/plugins/@management/init.ts
+++ b/src/plugins/@management/init.ts
@@ -92,7 +92,22 @@ const restart: OrderConfig = {
 	regexps: [],
 	auth: AuthLevel.Master,
 	main: "restart",
-	detail: "用于重启 bot，win 平台暂时无法使用"
+	detail: "用于重启 bot，使用win-start方式启动服务无法使用该指令"
+}
+
+const upgrade_plugins: OrderConfig = {
+	type: "order",
+	cmdKey: "adachi.hot-upgrade-plugins",
+	desc: [ "更新bot", "(-f) (插件名)" ],
+	headers: [ "upgrade_plugins" ],
+	regexps: [ "(-f)?", "([\u4E00-\u9FA5\\w\\-]+)?" ],
+	auth: AuthLevel.Master,
+	main: "upgrade-plugins",
+	detail: "该指令用于检测并更新 bot plugin 源码\n" +
+		"要求项目必须是通过 git clone 下载的且不能为 win-start 启动\n" +
+		"若存在更新则会更新插件并重启 bot\n" +
+		"在指令后追加 -f 来覆盖本地修改强制更新\n" +
+		"不指定插件名将更新全部支持热更新的插件"
 }
 
 export async function init(): Promise<PluginSetting> {
@@ -100,7 +115,7 @@ export async function init(): Promise<PluginSetting> {
 		pluginName: "@management",
 		cfgList: [
 			manager, ban, limit, interval,
-			refresh, upgrade, restart
+			refresh, upgrade, restart, upgrade_plugins
 		]
 	}
 }

--- a/src/plugins/@management/upgrade-plugins.ts
+++ b/src/plugins/@management/upgrade-plugins.ts
@@ -1,0 +1,188 @@
+import fetch from "node-fetch";
+import { exec } from "child_process";
+import { InputParameter } from "@modules/command";
+import { restart } from "pm2";
+import { PluginUpgradeServices } from "@modules/plugin";
+
+/* 超时检查 */
+function waitWithTimeout( promise: Promise<any>, timeout: number ): Promise<any> {
+	let timer;
+	const timeoutPromise = new Promise( ( _, reject ) => {
+		timer = setTimeout( () => reject( `timeout: ${ timeout }ms` ), timeout );
+	} );
+	return Promise.race( [ timeoutPromise, promise ] )
+		.finally( () => clearTimeout( timer ) );
+}
+
+/* 检查更新 */
+async function getCommitsInfo( repo: string ): Promise<any[]> {
+	const result: Response = await fetch( repo );
+	return await result.json();
+}
+
+/* 命令执行 */
+async function execHandle( command: string, cwd: string ): Promise<string> {
+	return new Promise( ( resolve, reject ) => {
+		exec( command, { cwd }, ( error, stdout, stderr ) => {
+			if ( error ) {
+				reject( error );
+			} else {
+				resolve( stdout );
+			}
+		} )
+	} )
+}
+
+/* 更新 plugin */
+async function updateBotPlugin( {
+	                                messageData,
+	                                sendMessage,
+	                                logger,
+	                                file
+                                }: InputParameter, pluginName: string, isForce: boolean = false ): Promise<void> {
+	const command = !isForce ? "git pull --no-rebase" : "git reset --hard && git pull --no-rebase";
+	const cwd = file.getFilePath( pluginName, "plugin" );
+	const execPromise = execHandle( command, cwd ).then( ( stdout: string ) => {
+		logger.info( stdout );
+		if ( /(Already up[ -]to[ -]date|已经是最新的)/.test( stdout ) ) {
+			throw "当前已经是最新版本了";
+		}
+	} );
+	
+	try {
+		await waitWithTimeout( execPromise, 30000 );
+	} catch ( error ) {
+		if ( typeof error === "string" ) {
+			const errMsg = error.includes( "timeout" ) ? "更新失败，网络请求超时" : error;
+			await sendMessage( errMsg );
+		} else {
+			await sendMessage( `更新失败，可能是网络出现问题${ !isForce ? "或存在代码冲突，若不需要保留改动代码可以追加 -f 使用强制更新" : "" }` );
+		}
+		logger.error( `更新 BOT Plugin:[${ pluginName }] 失败: ${ typeof error === "string" ? error : error.message }` );
+		throw error;
+	}
+	
+	await sendMessage( "更新成功，BOT 正在自行重启，请稍后" );
+}
+
+async function checkGitCommit( dbKey: string, i: InputParameter, repo: string ): Promise<{ check: boolean; newDate?: string }> {
+	const pluginName = dbKey.split( "." )[1];
+	const result: { check: boolean; newDate?: string } = { check: false };
+	let commits: any[] = []
+	try {
+		commits = await getCommitsInfo( repo );
+	} catch ( error ) {
+		i.logger.error( error );
+		await i.sendMessage( `[${ pluginName }]插件检查更新出错，可能是网络波动，请重试` );
+		return result;
+	}
+	
+	const newDate: string = commits[0].commit?.committer?.date;
+	const oldDate: string = await i.redis.getString( dbKey );
+	result.newDate = newDate;
+	
+	if ( !oldDate ) {
+		result.check = true;
+		await i.sendMessage( `初次使用指令更新[${ pluginName }]，将直接尝试更新该插件。` );
+		return result;
+	}
+	
+	const commitsNew = commits.filter( e => {
+		const commitDate: Date = new Date( e.commit?.committer?.date );
+		return Number( commitDate ) - Number( new Date( oldDate ) ) > 0;
+	} );
+	
+	if ( commitsNew.length === 0 ) {
+		await i.sendMessage( `[${ pluginName }]插件当前已经是最新版本了` );
+		return result;
+	}
+	
+	result.check = true;
+	return result;
+}
+
+export async function main( i: InputParameter ): Promise<void> {
+	const message: string = i.messageData.raw_message;
+	const reg: RegExp = new RegExp( /^(-f)?\s*([\u4E00-\u9FA5\w\-]+)?$/ );
+	const execArray: RegExpExecArray | null = reg.exec( message );
+	let dbKey: string = "";
+	let isForce: boolean = false;
+	if ( execArray && execArray[1] ) {
+		isForce = true;
+	}
+	if ( execArray && execArray[2] ) {
+		// 更新单个插件
+		const pluginName: string = execArray[2];
+		const repo: string = PluginUpgradeServices[pluginName];
+		if ( !repo ) {
+			await i.sendMessage( `[${ pluginName }]插件不支持热更新.` );
+			return;
+		}
+		
+		dbKey = `adachi.${ pluginName }.update-time`;
+		const checkResult: { check: boolean; newDate?: string } = await checkGitCommit( dbKey, i, repo );
+		if ( !checkResult.check ) {
+			if ( checkResult.newDate ) {
+				await i.redis.setString( dbKey, checkResult.newDate );
+			}
+			return;
+		}
+		try {
+			await updateBotPlugin( i, pluginName, isForce );
+			await i.sendMessage( `[${ pluginName }]插件更新完成，正在重启服务...` );
+			// 重启服务
+			restart( "adachi-bot", async ( error ) => {
+				await i.sendMessage( `重启 BOT 出错: ${ error }` );
+				throw error;
+			} );
+			
+			await i.redis.setString( dbKey, checkResult.newDate );
+		} catch ( e ) {
+			i.logger.error( e );
+		}
+		return;
+	}
+	
+	// 更新全部的插件
+	const upgrade_plugins: string[] = [];
+	const not_support_upgrade_plugins: string[] = [];
+	for ( let key in PluginUpgradeServices ) {
+		const repo: string = PluginUpgradeServices[key];
+		if ( repo ) {
+			dbKey = `adachi.${ key }.update-time`;
+			const checkResult: { check: boolean; newDate?: string } = await checkGitCommit( dbKey, i, repo );
+			if ( !checkResult.check ) {
+				if ( checkResult.newDate ) {
+					await i.redis.setString( dbKey, checkResult.newDate );
+				}
+				continue;
+			}
+			try {
+				await updateBotPlugin( i, key, isForce );
+				upgrade_plugins.push( key );
+				await i.redis.setString( dbKey, checkResult.newDate );
+			} catch ( e ) {
+				i.logger.error( e );
+			}
+		} else {
+			not_support_upgrade_plugins.push( key );
+		}
+	}
+	
+	if ( not_support_upgrade_plugins.length > 0 ) {
+		await i.sendMessage( `${ not_support_upgrade_plugins.join( "、" ) }不支持热更新` );
+	}
+	
+	if ( upgrade_plugins.length === 0 ) {
+		await i.sendMessage( "没有插件被更新!" );
+		return;
+	} else {
+		await i.sendMessage( `${ upgrade_plugins.join( "、" ) }已完成更新，正在重启服务...` );
+	}
+	
+	// 重启服务
+	restart( "adachi-bot", async ( error ) => {
+		i.logger.error( error );
+		await i.sendMessage( `重启 BOT 出错: ${ error }` );
+	} );
+}

--- a/src/plugins/genshin/utils/api.ts
+++ b/src/plugins/genshin/utils/api.ts
@@ -4,7 +4,7 @@ import { toCamelCase } from "./camel-case";
 import { set } from "lodash";
 import { guid } from "../utils/guid";
 import { getDS, getDS2 } from "./ds";
-import { ResponseBody, InfoResponse } from "#genshin/types";
+import { InfoResponse, ResponseBody } from "#genshin/types";
 import { SlipDetail } from "../module/slip";
 import { DailyMaterial } from "../module/daily";
 import { FortuneData } from "../module/almanac";
@@ -37,9 +37,9 @@ const __API = {
 };
 
 const HEADERS = {
-	"User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) miHoYoBBS/2.11.1",
+	"User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) miHoYoBBS/2.29.1",
 	"Referer": "https://webstatic.mihoyo.com/",
-	"x-rpc-app_version": "2.11.1",
+	"x-rpc-app_version": "2.29.1",
 	"x-rpc-client_type": 5,
 	"DS": "",
 	"Cookie": ""


### PR DESCRIPTION
- 添加 热更新插件 `#upgrade_plugins` 指令 (需要插件开发者添加仓库的名称来支持此功能)
- 修复深渊战斗数据缺失的问题

```ts
export async function init( bot: BOT ): Promise<PluginSetting> {
	return {
		pluginName: "setu-plugin",
		cfgList: [ setu ],
		repo: "BennettChina/setu-plugin"// 此为仓库持有者的Github名称和仓库名，也即仓库GitHub地址去掉Github域名后的那部分
	};
}
```