### PR TITLE
support plugin not at default branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adachi-bot",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adachi-bot",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "ISC",
       "dependencies": {
         "@types/body-parser": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "adachi-bot",
-  "version" : "2.6.0",
+  "version" : "2.6.1",
   "description" : "",
   "main" : "index.js",
   "scripts" : {

--- a/src/modules/plugin.ts
+++ b/src/modules/plugin.ts
@@ -17,7 +17,11 @@ export type PluginSubSetting = {
 export interface PluginSetting {
 	pluginName: string;
 	cfgList: cmd.ConfigType[];
-	repo?: string; // 设置为非必须兼容低版本插件
+	repo?: string | {
+		owner: string;// 仓库拥有者名称
+		repoName: string;// 仓库名称
+		ref?: string;// 分支名称
+	}; // 设置为非必须兼容低版本插件
 }
 
 export const PluginReSubs: Record<string, PluginSubSetting> = {};
@@ -47,7 +51,15 @@ export default class Plugin {
 				const commands = Plugin.parse( bot, cfgList, pluginName );
 				PluginRawConfigs[pluginName] = cfgList;
 				if ( !not_support_upgrade_plugins.includes( pluginName ) ) {
-					PluginUpgradeServices[pluginName] = repo ? `https://api.github.com/repos/${ repo }/commits` : "";
+					if ( repo ) {
+						if ( typeof repo === "string" ) {
+							PluginUpgradeServices[pluginName] = repo ? `https://api.github.com/repos/${ repo }/commits` : "";
+						} else {
+							PluginUpgradeServices[pluginName] = repo.ref ? `https://api.github.com/repos/${ repo.owner }/${ repo.repoName }/commits/${ repo.ref }` : `https://api.github.com/repos/${ repo.owner }/${ repo.repoName }/commits`;
+						}
+					} else {
+						PluginUpgradeServices[pluginName] = "";
+					}
 				}
 				registerCmd.push( ...commands );
 				bot.logger.info( `插件 ${ pluginName } 加载完成` );

--- a/src/plugins/@management/init.ts
+++ b/src/plugins/@management/init.ts
@@ -98,7 +98,7 @@ const restart: OrderConfig = {
 const upgrade_plugins: OrderConfig = {
 	type: "order",
 	cmdKey: "adachi.hot-upgrade-plugins",
-	desc: [ "更新bot", "(-f) (插件名)" ],
+	desc: [ "更新插件", "(-f) (插件名)" ],
 	headers: [ "upgrade_plugins" ],
 	regexps: [ "(-f)?", "([\u4E00-\u9FA5\\w\\-]+)?" ],
 	auth: AuthLevel.Master,

--- a/src/plugins/@management/upgrade-plugins.ts
+++ b/src/plugins/@management/upgrade-plugins.ts
@@ -17,7 +17,11 @@ function waitWithTimeout( promise: Promise<any>, timeout: number ): Promise<any>
 /* 检查更新 */
 async function getCommitsInfo( repo: string ): Promise<any[]> {
 	const result: Response = await fetch( repo );
-	return await result.json();
+	const json = await result.json();
+	if ( typeof json === "object" ) {
+		return [ json ];
+	}
+	return json;
 }
 
 /* 命令执行 */


### PR DESCRIPTION
支持不在仓库默认分支的插件热更新。

```ts
export async function init(): Promise<PluginSetting> {
	return {
		pluginName: "music",
		cfgList: [ getMusic, toggleSource ],
		repo: {
			owner: "SilveryStar",// 仓库拥有者名称
			repoName: "Adachi-Plugin",// 仓库名称
			ref: "music" //分支名称
		}
	};
}
```