### PR TITLE
Update to v2.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adachi-bot",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adachi-bot",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -31,6 +31,7 @@ export default class BotConfig {
 		readonly enable: boolean;
 		readonly consolePort: number;
 		readonly tcpLoggerPort: number;
+		readonly logHighWaterMark: number;
 		readonly jwtSecret: string;
 	};
 	
@@ -69,6 +70,7 @@ export default class BotConfig {
 			enable: true,
 			consolePort: 80,
 			tcpLoggerPort: 54921,
+			logHighWaterMark: 64,
 			jwtSecret: randomSecret( 16 )
 		},
 		autoChat: {
@@ -124,6 +126,7 @@ export default class BotConfig {
 			enable: config.webConsole.enable,
 			consolePort: config.webConsole.consolePort,
 			tcpLoggerPort: config.webConsole.tcpLoggerPort,
+			logHighWaterMark: config.webConsole.logHighWaterMark,
 			jwtSecret: config.webConsole.jwtSecret
 		}
 		

--- a/src/plugins/genshin/achieves/private/query/appoint.ts
+++ b/src/plugins/genshin/achieves/private/query/appoint.ts
@@ -14,10 +14,15 @@ export async function main( { sendMessage, messageData }: InputParameter ): Prom
 	if ( typeof single === "string" ) {
 		await sendMessage( single );
 	} else {
+		if ( name === "empty" ) {
+			await ( <MysQueryService>single.services[MysQueryService.FixedField] ).modifyAppointChar( name );
+			await sendMessage( "卡片指定头像清除成功" );
+			return;
+		}
 		const result: NameResult = getRealName( name );
 		if ( result.definite ) {
 			const realName: string = <string>result.info;
-			await ( <MysQueryService>single.services[ MysQueryService.FixedField ] ).modifyAppointChar(
+			await ( <MysQueryService>single.services[MysQueryService.FixedField] ).modifyAppointChar(
 				characterID.map[realName].toString()
 			);
 			await sendMessage( "卡片头像指定成功" );

--- a/src/plugins/genshin/achieves/private/query/mys.ts
+++ b/src/plugins/genshin/achieves/private/query/mys.ts
@@ -28,13 +28,15 @@ export async function main(
 	}
 	
 	const appointId = info.options[MysQueryService.FixedField].appoint;
-	let appointName = "";
+	let appointName: string = "empty";
 	
-	for ( const name in characterID.map ) {
-		const mapId = characterID.map[name];
-		if ( mapId === parseInt( appointId ) ) {
-			appointName = name;
-			break;
+	if ( appointId !== "empty" ) {
+		for ( const name in characterID.map ) {
+			const mapId = characterID.map[name];
+			if ( mapId === parseInt( appointId ) ) {
+				appointName = name;
+				break;
+			}
 		}
 	}
 	

--- a/src/plugins/genshin/setting.ts
+++ b/src/plugins/genshin/setting.ts
@@ -270,12 +270,13 @@ const privateNoteEvent: OrderConfig = {
 const privateMysSetAppoint: OrderConfig = {
 	type: "order",
 	cmdKey: "silvery-star.private-set-appoint",
-	desc: [ "指定头像", "[账户序号] [角色名]" ],
+	desc: [ "指定头像", "[账户序号] [角色名|empty]" ],
 	headers: [ "appoint" ],
 	regexps: [ "\\d+", "[\\w\\u4e00-\\u9fa5]+" ],
 	main: "achieves/private/query/appoint",
 	scope: MessageScope.Private,
-	detail: "该指令用于指定查询卡片中的头像图片"
+	detail: "该指令用于指定查询卡片中的头像图片\n" +
+			"使用 empty 恢复默认状态"
 };
 
 const privateMysQuery: OrderConfig = {

--- a/src/web-console/assets/styles/components.css
+++ b/src/web-console/assets/styles/components.css
@@ -18,7 +18,7 @@
 .form-item > .el-form-item__content {
 	width: 70%;
 	font-size: 12px;
-	line-height: 16px;
+	line-height: 0;
 	flex: 0 0 auto;
 }
 

--- a/src/web-console/backend/routes/log.ts
+++ b/src/web-console/backend/routes/log.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import bot from "ROOT";
 
-export default express.Router().get( "/", ( req, res ) => {
+export default express.Router().get( "/", async ( req, res ) => {
 	const page = parseInt( <string>req.query.page ); // 当前第几页
 	const length = parseInt( <string>req.query.length ); // 页长度
 	const logLevel = <string>req.query.logLevel; // 日志等级
@@ -20,7 +20,7 @@ export default express.Router().get( "/", ( req, res ) => {
 	
 	try {
 		if ( bot.file.isExist( path ) ) {
-			const file = bot.file.readFile( fileName, "root" );
+			const file = await bot.file.readFileByStream( fileName, "root", bot.config.webConsole.logHighWaterMark );
 			const fullData = file.split( /[\n\r]/g ).filter( el => el.length !== 0 );
 			const respData = fullData
 				.map( el => JSON.parse( el ) )

--- a/src/web-console/views/dashboard/setting.js
+++ b/src/web-console/views/dashboard/setting.js
@@ -147,6 +147,14 @@ const template = `<div class="table-container config">
 					@change="updateConfig('webConsole.tcpLoggerPort')"
 				/>
 				<spread-form-item
+					v-model="setting.webConsole.logHighWaterMark"
+					:disabled="pageLoading"
+					label="读日志数据量"
+					type="number"
+					desc="控制日志单次读取的数据量，单位 kb，不填或置 0 时默认 64，越大读取越快，内存占用越大，反之同理。"
+					@change="updateConfig('webConsole.logHighWaterMark')"
+				/>
+				<spread-form-item
 					v-model="setting.webConsole.jwtSecret"
 					:disabled="pageLoading"
 					label="JWT验证秘钥"

--- a/src/web-console/views/log.js
+++ b/src/web-console/views/log.js
@@ -42,6 +42,9 @@ const template = `<div class="table-container fix-height logger">
 		<p v-else-if="error" class="empty-promote">
 			未找到{{ currentDate.getMonth() + 1 }}月{{ currentDate.getDate() }}日的日志...
 		</p>
+		<p v-else-if="loading" class="empty-promote">
+			正在获取日志记录，请稍后...
+		</p>
 		<div v-else class="log-window">
 			<el-scrollbar ref="scrollbarRef" class="log-scroll-container">
 				<p v-for="m in list" class="content-line">
@@ -79,6 +82,7 @@ export default defineComponent( {
 			currentDate: new Date(),
 			today: true,
 			autoBottom: true,
+			loading: false,
 			error: false,
 			currentPage: 1,
 			pageSize: 750,
@@ -182,6 +186,7 @@ export default defineComponent( {
 		
 		/* 获取日志列表 */
 		async function getLogsData( date = state.currentDate ) {
+			state.loading = true;
 			try {
 				const resp = await $http.LOG_INFO( {
 					date: date.getTime(),
@@ -196,8 +201,10 @@ export default defineComponent( {
 				} else {
 					state.error = true;
 				}
+				state.loading = false;
 			} catch ( error ) {
 				state.error = true;
+				state.loading = false;
 			}
 		}
 		


### PR DESCRIPTION
- 指令 `appoint` 新增可选项 `empty`，用于清除已指定的头像
- 修复`mys` 图片头像加载失败问题
- 修复日志文件过大时，控制台打开日志页面内存占用过高导致崩溃问题
- 新增配置项 `webconsole.logHighWaterMark`，用于控制单次读取日志文件的数据量大小