### PR TITLE
Support for cmd in reply messages.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adachi-bot",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adachi-bot",
-      "version": "2.6.10",
+      "version": "2.7.3",
       "license": "ISC",
       "dependencies": {
         "@types/body-parser": "~1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adachi-bot",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/modules/bot.ts
+++ b/src/modules/bot.ts
@@ -304,7 +304,7 @@ export default class Adachi {
 		isPrivate: boolean,
 		isAt: boolean
 	): Promise<void> {
-		const content: string = messageData.raw_message.trim() || '';
+		let content: string = messageData.raw_message.replace( /\[CQ:reply,id=[\w=]+]/, "" ).trim() || '';
 		
 		if ( this.bot.refresh.isRefreshing ) {
 			return;


### PR DESCRIPTION
支持在回复消息中使用指令，可以通过此方法获取到用户上传的文件等信息。

```ts
export async function main( { sendMessage, messageData, client, logger }: InputParameter ): Promise<void> {
	const { message, raw_message } = messageData;
        // 引用消息只会有一条
	const { data: { id } }: ReplyElem = <ReplyElem>message.filter( msg => msg.type === 'reply' )[0]
	const { retcode, error, data }: Ret<PrivateMessageEventData | GroupMessageEventData> = await client.getMsg( id );
	if ( retcode !== 0 ) {
		logger.error( "获取引用消息失败:", error );
		await sendMessage( "获取引用消息失败" );
		return;
	}
	
	const file_url = data.message[0].data.url;
}
```