### PR TITLE
fix two bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adachi-bot",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adachi-bot",
-      "version": "2.7.3",
+      "version": "2.7.4",
       "license": "ISC",
       "dependencies": {
         "@types/body-parser": "~1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adachi-bot",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/modules/bot.ts
+++ b/src/modules/bot.ts
@@ -304,7 +304,9 @@ export default class Adachi {
 		isPrivate: boolean,
 		isAt: boolean
 	): Promise<void> {
-		let content: string = messageData.raw_message.replace( /\[CQ:reply,id=[\w=]+]/, "" ).trim() || '';
+		// 群组内的回复消息会at被回复的用户，需要把这个内容也去掉
+		const replyReg = new RegExp( `\\[CQ:reply,id=[\\w=+/]+]\\s*(\\[CQ:at,qq=\\d+,text=.*])?` );
+		let content: string = messageData.raw_message.replace( replyReg, "" ).trim() || '';
 		
 		if ( this.bot.refresh.isRefreshing ) {
 			return;
@@ -474,12 +476,10 @@ export default class Adachi {
 	
 	private checkAtBOT( msg: sdk.GroupMessageEventData ): boolean {
 		const { number } = this.bot.config;
-		const atBOTReg: RegExp = new RegExp( `^ *\\[CQ:at,qq=${ number }.*?]` );
-		const content: string = msg.raw_message;
-		
-		if ( atBOTReg.test( content ) ) {
-			msg.raw_message = content
-				.replace( atBOTReg, "" )
+		if ( msg.atme ) {
+			const atBotReg = new RegExp( `\\[CQ:at,qq=${number}.*?]` );
+			msg.raw_message = msg.raw_message
+				.replace( atBotReg, "" )
 				.trim();
 			return true;
 		}


### PR DESCRIPTION
- 修复 `checkAtBOT` 函数在回复消息中无法识别到 `atBOT` 的问题，改为使用 `oicq` 消息中的 `atme` 的值，然后把 消息中的`AT` 的 `CQ` 字符串删除掉。
- 修复回复消息在群聊中未处理后面的 `at` 对方的 `CQ` 字符串问题。