### PR TITLE
fix one bug and add feature.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adachi-bot",
-  "version": "2.7.6-bugfix",
+  "version": "2.7.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adachi-bot",
-      "version": "2.7.5",
+      "version": "2.7.7",
       "license": "ISC",
       "dependencies": {
         "@types/body-parser": "~1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adachi-bot",
-  "version": "2.7.6-bugfix",
+  "version": "2.7.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/modules/bot.ts
+++ b/src/modules/bot.ts
@@ -221,8 +221,8 @@ export default class Adachi {
 						return;
 					}
 					const file = this.bot.file.loadFile( ticketPath, "root" );
-					if ( file ) {
-						this.bot.client.sliderLogin( file );
+					if ( file && file.trim() ) {
+						this.bot.client.sliderLogin( file.trim() );
 						job.cancel();
 						this.bot.file.writeFile( ticketPath, "", "root" );
 					}
@@ -255,8 +255,8 @@ export default class Adachi {
 							return;
 						}
 						const file: string = this.bot.file.loadFile( codePath, "root" );
-						if ( file ) {
-							this.bot.client.submitSMSCode( file );
+						if ( file && file.trim() ) {
+							this.bot.client.submitSMSCode( file.trim() );
 							job.cancel();
 							this.bot.file.writeFile( codePath, "", "root" );
 						}

--- a/src/modules/plugin.ts
+++ b/src/modules/plugin.ts
@@ -17,6 +17,7 @@ export type PluginSubSetting = {
 export interface PluginSetting {
 	pluginName: string;
 	cfgList: cmd.ConfigType[];
+	aliases?: string[];
 	repo?: string | {
 		owner: string;// 仓库拥有者名称
 		repoName: string;// 仓库名称
@@ -29,6 +30,8 @@ export const PluginReSubs: Record<string, PluginSubSetting> = {};
 export const PluginRawConfigs: Record<string, cmd.ConfigType[]> = {};
 
 export const PluginUpgradeServices: Record<string, string> = {};
+
+export const PluginAlias: Record<string, string> = {};
 
 // 不支持热更新的插件集合，这些插件不会被提示不支持热更新。
 const not_support_upgrade_plugins: string[] = [ "@help", "@management", "genshin", "tools" ];
@@ -43,7 +46,7 @@ export default class Plugin {
 			const path: string = bot.file.getFilePath( `${ plugin }/init`, "plugin" );
 			const { init, subInfo } = require( path );
 			try {
-				const { pluginName, cfgList, repo }: PluginSetting = await init( bot );
+				const { pluginName, cfgList, repo, aliases }: PluginSetting = await init( bot );
 				if ( subInfo ) {
 					const { reSub, subs }: PluginSubSetting = await subInfo( bot );
 					PluginReSubs[pluginName] = { reSub, subs };
@@ -59,6 +62,11 @@ export default class Plugin {
 						}
 					} else {
 						PluginUpgradeServices[pluginName] = "";
+					}
+				}
+				if ( aliases && aliases.length > 0 ) {
+					for ( let alias of aliases ) {
+						PluginAlias[alias] = pluginName;
 					}
 				}
 				registerCmd.push( ...commands );

--- a/src/plugins/@management/upgrade-plugins.ts
+++ b/src/plugins/@management/upgrade-plugins.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import { exec } from "child_process";
 import { InputParameter } from "@modules/command";
 import { restart } from "pm2";
-import { PluginUpgradeServices } from "@modules/plugin";
+import { PluginAlias, PluginUpgradeServices } from "@modules/plugin";
 
 /* 超时检查 */
 function waitWithTimeout( promise: Promise<any>, timeout: number ): Promise<any> {
@@ -122,7 +122,12 @@ export async function main( i: InputParameter ): Promise<void> {
 	}
 	if ( execArray && execArray[3] ) {
 		// 更新单个插件
-		const pluginName: string = execArray[3];
+		let pluginName: string = execArray[3];
+		const originalName = PluginAlias[pluginName];
+		if ( originalName ) {
+			// 如果是用的别名则重置成插件的原始名称
+			pluginName = originalName;
+		}
 		const repo: string = PluginUpgradeServices[pluginName];
 		if ( !repo ) {
 			await i.sendMessage( `[${ pluginName }]插件不支持热更新.` );


### PR DESCRIPTION
- 修复登录时输入的 `ticket` 或者 `code` 为空字符串时仍会触发登录。
- `upgrade-plugins` 指令支持使用别名更新插件（需要插件开发者支持）。

以下为插件的定义信息：

```ts
interface PluginSetting {
	pluginName: string;
	cfgList: cmd.ConfigType[];
	aliases?: string[]; // 插件的别名
	repo?: string | {
		owner: string;// 仓库拥有者名称
		repoName: string;// 仓库名称
		ref?: string;// 分支名称
	}; // 设置为非必须兼容低版本插件
}
```