### PR TITLE
uppdate to 2.9.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adachi-bot",
-  "version": "2.9.9",
+  "version": "2.9.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adachi-bot",
-      "version": "2.9.9",
+      "version": "2.9.10",
       "license": "ISC",
       "dependencies": {
         "@types/body-parser": "~1.19.1",
@@ -29,7 +29,7 @@
         "exceljs": "^4.3.0",
         "express-jwt": "~6.1.0",
         "express-ws": "~5.0.2",
-        "icqq": "^0.3.10",
+        "icqq": "^0.3.14",
         "jsonwebtoken": "~8.5.1",
         "lodash": "~4.17.21",
         "log4js": "~6.3.0",
@@ -3315,9 +3315,9 @@
       }
     },
     "node_modules/icqq": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmmirror.com/icqq/-/icqq-0.3.10.tgz",
-      "integrity": "sha512-54MO74jSZgwXNpr0VBx7akp50IM6qNGYV8ZrCs9PDfcrtb3jpxhxwW9xHBBBgzzHFdbWv6/WggJjuexEttQRKQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmmirror.com/icqq/-/icqq-0.3.14.tgz",
+      "integrity": "sha512-j78EPWQ8T4ribXBqp0JOvwYJc4JMbWyCS1l2R7vlJSHf53YJCbsmyTaQPFltePd5eApNuKRHgRZ1DwVc7KoG0Q==",
       "dependencies": {
         "axios": "^1.1.2",
         "log4js": "^6.3.0",
@@ -9333,9 +9333,9 @@
       }
     },
     "icqq": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmmirror.com/icqq/-/icqq-0.3.10.tgz",
-      "integrity": "sha512-54MO74jSZgwXNpr0VBx7akp50IM6qNGYV8ZrCs9PDfcrtb3jpxhxwW9xHBBBgzzHFdbWv6/WggJjuexEttQRKQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmmirror.com/icqq/-/icqq-0.3.14.tgz",
+      "integrity": "sha512-j78EPWQ8T4ribXBqp0JOvwYJc4JMbWyCS1l2R7vlJSHf53YJCbsmyTaQPFltePd5eApNuKRHgRZ1DwVc7KoG0Q==",
       "requires": {
         "axios": "^1.1.2",
         "log4js": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "adachi-bot",
-  "version" : "2.9.9",
+  "version" : "2.9.10",
   "description" : "",
   "main" : "index.js",
   "scripts" : {
@@ -37,7 +37,7 @@
     "exceljs" : "^4.3.0",
     "express-jwt" : "~6.1.0",
     "express-ws" : "~5.0.2",
-    "icqq" : "^0.3.10",
+    "icqq" : "^0.3.14",
     "jsonwebtoken" : "~8.5.1",
     "lodash" : "~4.17.21",
     "log4js" : "~6.3.0",

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -29,53 +29,6 @@ export default class BotConfig {
 	public readonly callTimes: number;
 	public readonly logLevel: "trace" | "debug" | "info" | "warn" |
 		"error" | "fatal" | "mark" | "off";
-	
-	public readonly mailConfig: {
-		readonly host: string;
-		readonly port: number;
-		readonly user: string;
-		readonly pass: string;
-		readonly secure: boolean;
-		readonly servername: string;
-		readonly rejectUnauthorized: boolean;
-		readonly logoutSend: boolean;
-		readonly sendDelay: number;
-		readonly retry: number;
-		readonly retryWait: number;
-	}
-	
-	public readonly banScreenSwipe: {
-		readonly enable: boolean;
-		readonly limit: number;
-		readonly duration: number;
-		readonly prompt: boolean;
-		readonly promptMsg: string;
-	}
-	
-	public readonly banHeavyAt: {
-		readonly enable: boolean;
-		readonly limit: number;
-		readonly duration: number;
-		readonly prompt: boolean;
-		readonly promptMsg: string;
-	}
-	
-	public readonly webConsole: {
-		readonly enable: boolean;
-		readonly consolePort: number;
-		readonly tcpLoggerPort: number;
-		readonly logHighWaterMark: number;
-		readonly jwtSecret: string;
-	};
-	
-	public readonly autoChat: {
-		readonly enable: boolean;
-		readonly type: number;
-		readonly audio: boolean;
-		readonly secretId: string;
-		readonly secretKey: string;
-	}
-	
 	static initObject = {
 		tip: "前往 https://docs.adachi.top/config 查看配置详情",
 		qrcode: false,
@@ -101,6 +54,7 @@ export default class BotConfig {
 		helpMessageStyle: "message",
 		callTimes: 3,
 		logLevel: "info",
+		logKeepDays: 30,
 		dbPort: 56379,
 		dbPassword: "",
 		mailConfig: {
@@ -150,6 +104,53 @@ export default class BotConfig {
 		}
 	};
 	
+	public readonly mailConfig: {
+		readonly host: string;
+		readonly port: number;
+		readonly user: string;
+		readonly pass: string;
+		readonly secure: boolean;
+		readonly servername: string;
+		readonly rejectUnauthorized: boolean;
+		readonly logoutSend: boolean;
+		readonly sendDelay: number;
+		readonly retry: number;
+		readonly retryWait: number;
+	}
+	
+	public readonly banScreenSwipe: {
+		readonly enable: boolean;
+		readonly limit: number;
+		readonly duration: number;
+		readonly prompt: boolean;
+		readonly promptMsg: string;
+	}
+	
+	public readonly banHeavyAt: {
+		readonly enable: boolean;
+		readonly limit: number;
+		readonly duration: number;
+		readonly prompt: boolean;
+		readonly promptMsg: string;
+	}
+	
+	public readonly webConsole: {
+		readonly enable: boolean;
+		readonly consolePort: number;
+		readonly tcpLoggerPort: number;
+		readonly logHighWaterMark: number;
+		readonly jwtSecret: string;
+	};
+	
+	public readonly autoChat: {
+		readonly enable: boolean;
+		readonly type: number;
+		readonly audio: boolean;
+		readonly secretId: string;
+		readonly secretKey: string;
+	}
+	public readonly logKeepDays: number;
+	
 	constructor( file: FileManagement ) {
 		const config: any = file.loadYAML( "setting" );
 		const checkFields: Array<keyof BotConfig> = [
@@ -157,7 +158,7 @@ export default class BotConfig {
 			"helpPort", "autoChat", "callTimes",
 			"fuzzyMatch", "matchPrompt", "useWhitelist",
 			"banScreenSwipe", "banHeavyAt", "ThresholdInterval",
-			"ffmpegPath", "ffprobePath", "mailConfig"
+			"ffmpegPath", "ffprobePath", "mailConfig", "logKeepDays"
 		];
 		
 		for ( let key of checkFields ) {
@@ -249,5 +250,6 @@ export default class BotConfig {
 		];
 		this.logLevel = logLevelList.includes( config.logLevel )
 			? config.logLevel : "info";
+		this.logKeepDays = config.logKeepDays;
 	}
 }

--- a/src/modules/renderer.ts
+++ b/src/modules/renderer.ts
@@ -108,13 +108,7 @@ export class Renderer implements ScreenshotRendererMethods {
 		try {
 			const url: string = this.getURL( route, params );
 			const data: Buffer | string | void = await bot.renderer.screenshotForFunction( url, viewPort, pageFunction );
-			if ( !data ) {
-				return { code: "ok", data: "" };
-			}
-			if ( typeof data === 'string' ) {
-				return { code: "ok", data: segment.image( `base64://${ data }` ) };
-			}
-			return { code: "ok", data: segment.image( data ) };
+			return { code: "ok", data: data ? segment.image( data ) : "" };
 		} catch ( error ) {
 			const err = <string>( <Error>error ).stack;
 			return { code: "error", error: err };
@@ -253,6 +247,11 @@ export class BasicRenderer implements RenderMethods {
 			this.screenshotCount++;
 			if ( this.screenshotCount >= BasicRenderer.screenshotLimit ) {
 				await bot.renderer.restartBrowser();
+			}
+			
+			if ( result && typeof result === 'string' ) {
+				// 兼容低版本插件的返回
+				return result.startsWith( "base64://" ) ? result : `base64://${ result }`;
 			}
 			
 			return result;

--- a/src/web-console/backend/routes/log.ts
+++ b/src/web-console/backend/routes/log.ts
@@ -31,7 +31,7 @@ export default express.Router().get( "/", async ( req, res ) => {
 					}
 					/* 过滤消息类型 */
 					if ( !Number.isNaN( msgType ) ) {
-						const reg = /^(?:send to|recv from): \[(Group|Private): .*?(\d+)/;
+						const reg = /^(?:succeed to send|recv from): \[(Group|Private)(?:\(|: |: .*?)(\d+).*].*?/;
 						const result = reg.exec( el.message );
 						if ( result ) {
 							const type = <'Group' | 'Private'>result[1];

--- a/src/web-console/views/log.js
+++ b/src/web-console/views/log.js
@@ -212,7 +212,7 @@ export default defineComponent( {
 				}
 				/* 过滤消息类型 */
 				if ( !Number.isNaN( msgType ) ) {
-					const reg = /^(?:send to|recv from): \[(Group|Private): .*?(\d+)/;
+					const reg = /^(?:succeed to send|recv from): \[(Group|Private)(?:\(|: |: .*?)(\d+).*].*?/;
 					const result = reg.exec( el.message );
 					if ( result ) {
 						const type = result[1];
@@ -389,10 +389,10 @@ export default defineComponent( {
 				.toString()
 				.split( "\n\n" )
 				.map( el => {
-					el = el.replace( /\[(Android|aPad|Watch|iMac|iPad):\d+]/, "[$1:*****]" )
-						.replace( / - recv from: \[Private: \d+\((friend|group)\)] (.*)/, " [Recv] [Pri-$1] $2" )
-						.replace( / - recv from: \[Group: .*] (.*)/, " [Recv] [Group] $1" )
-						.replace( / - send to: \[(Group|Private): .*]/, " [Send] [$1] ---" )
+					el = el.replace( /\[(Android|aPad|Watch|iMac|iPad|Android_8.8.88):\d+]/g, "[$1:*****]" )
+						.replace( / - recv from: \[Private: \d+\((friend|group)\)] (.*)/g, " [Recv] [Pri-$1] $2" )
+						.replace( / - recv from: \[Group: .*] (.*)/g, " [Recv] [Group] $1" )
+						.replace( / - succeed to send: \[(Group|Private).*]/g, " [Send] [$1] ---" )
 						.replace( /(\[[A-Z]+]) - (.*)/, "$1 [Event] $2" )
 						.replace( /&#93;/g, "]" )
 						.replace( /&#91;/g, "[" );


### PR DESCRIPTION
- 修复日志打印时不支持多参数的问题；
- 修复 `WebConsole` 日志过滤部分功能及去隐私复制功能的 BUG
- 日志保存设置自动删除日期（默认30天），可通过 `logKeepDays` 修改配置
- 默认开启 `stdout` 类型日志（看官方文档似乎不会有 `console` 类型的占内存问题）
- upgrade `icqq` to `0.3.14`
- 兼容低版本插件的渲染返回值