### PR TITLE
upgrade to 2.9.12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,24 @@ services:
       docker: "yes"
     depends_on:
       - redis
+      - qsign
     volumes:
       - ./:/bot
       - /bot/node_modules/
+  qsign:
+    image: bennettwu/qsign-server:1.1.4
+    container_name: qsign
+    # 如果需要把这个服务让其他 BOT 调用可以把端口映射到宿主机
+    #    ports:
+    #      - "8080:80"
+    deploy:
+      resources:
+        limits:
+          memory: 300M
+          cpus: '0.7'
+      # 不挂载资源默认用8.9.63，key是114514，最终地址为http://qsign/sign?key=114514
+      # 如果要修改则需要挂载资源
+      #    volumes:
+      # 可以放txlib目录中的.so文件
+    #      - ./qsign/txlib/:/app/txlib
+    restart: always

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adachi-bot",
-  "version": "2.9.11",
+  "version": "2.9.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adachi-bot",
-      "version": "2.9.11",
+      "version": "2.9.12",
       "license": "ISC",
       "dependencies": {
         "@types/body-parser": "~1.19.1",
@@ -29,7 +29,7 @@
         "exceljs": "^4.3.0",
         "express-jwt": "~6.1.0",
         "express-ws": "~5.0.2",
-        "icqq": "^0.4.6",
+        "icqq": "^0.4.10",
         "jsonwebtoken": "~8.5.1",
         "lodash": "~4.17.21",
         "log4js": "~6.3.0",
@@ -3315,9 +3315,9 @@
       }
     },
     "node_modules/icqq": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmmirror.com/icqq/-/icqq-0.4.6.tgz",
-      "integrity": "sha512-4xouhdzh6EYa8WjEH84VsXgajyZbJ1WKH6684F7my/r8pwzhTGGfRrUCjKnujZfFK3pHLlWU+lh40UuvXt0eOA==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmmirror.com/icqq/-/icqq-0.4.10.tgz",
+      "integrity": "sha512-pipvj9sbqVfa1qejHg8TBCvMzTxCZXhPr1tmt9HHy4y3wGt8OwpOpjlh3L8TzSxL6jOTHBQ/3L9g/20wh/ftbw==",
       "dependencies": {
         "axios": "^1.1.2",
         "log4js": "^6.3.0",
@@ -9333,9 +9333,9 @@
       }
     },
     "icqq": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmmirror.com/icqq/-/icqq-0.4.6.tgz",
-      "integrity": "sha512-4xouhdzh6EYa8WjEH84VsXgajyZbJ1WKH6684F7my/r8pwzhTGGfRrUCjKnujZfFK3pHLlWU+lh40UuvXt0eOA==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmmirror.com/icqq/-/icqq-0.4.10.tgz",
+      "integrity": "sha512-pipvj9sbqVfa1qejHg8TBCvMzTxCZXhPr1tmt9HHy4y3wGt8OwpOpjlh3L8TzSxL6jOTHBQ/3L9g/20wh/ftbw==",
       "requires": {
         "axios": "^1.1.2",
         "log4js": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "adachi-bot",
-  "version" : "2.9.11",
+  "version" : "2.9.12",
   "description" : "",
   "main" : "index.js",
   "scripts" : {
@@ -37,7 +37,7 @@
     "exceljs" : "^4.3.0",
     "express-jwt" : "~6.1.0",
     "express-ws" : "~5.0.2",
-    "icqq" : "^0.4.6",
+    "icqq" : "^0.4.10",
     "jsonwebtoken" : "~8.5.1",
     "lodash" : "~4.17.21",
     "log4js" : "~6.3.0",

--- a/src/web-console/views/dashboard/setting.js
+++ b/src/web-console/views/dashboard/setting.js
@@ -56,6 +56,16 @@ const template = `<div class="table-container config">
 			<form-item label="阈值使用限制" desc="开启后当用户使用超过阈值时，本小时内 BOT 将不再响应其指令。">
 				<el-switch v-model="setting.ThresholdInterval" :disabled="pageLoading" @change="updateConfig('ThresholdInterval')" />
 			</form-item>
+			<spread-form-item
+				v-model="setting.signApiAddr"
+				:active-spread="activeSpread"
+				:disabled="pageLoading"
+				label="登录签名API地址"
+				desc="参考 unidbg-fetch-qsign 项目，Docker用户会直接启动一个Qsign，即提示的地址，这个项目只能用协议1和2。"
+				placeholder="http://qsign/sign?key=114514"
+				@change="updateConfig('signApiAddr')"
+				@open="activeSpreadItem"
+			/>
 		</div>
 		<div class="config-section">
 			<section-title title="指令设置" />


### PR DESCRIPTION
- 升级 icqq 到 `0.4.10`；
- 添加一个默认的 `qsign` 容器，需要改参数则需要自行挂载qsign服务的配置；
- WebConsole 添加 `signApiAddr` 的配置管理。

#### 提示

关于默认 `qsign` 容器的挂载可在服务启动后用下面的命令把容器内的文件复制到宿主机**当前目录的qsign目录**中。

```sh
docker cp qsign:/app/txlib "$(pwd)/qsign/"
```

然后修改 `txlib/config.json` 中的内容重启服务即可。

具体配置等可参考镜像说明[docker-qsign](https://github.com/BennettChina/docker-qsign) 和 [unidbg-fetch-qsign](https://github.com/fuqiuluo/unidbg-fetch-qsign)